### PR TITLE
Update README and Nix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,20 @@ To try it out:
 # nix build # to build the Wasm functions
 
 # ls -l ./result/
--r--r--r-- 3 root root  17396 Jan  1  1970 nix_wasm_plugin_fib.wasm
--r--r--r-- 3 root root  64292 Jan  1  1970 nix_wasm_plugin_ini.wasm
--r--r--r-- 3 root root  33277 Jan  1  1970 nix_wasm_plugin_mandelbrot.wasm
--r--r--r-- 3 root root  29635 Jan  1  1970 nix_wasm_plugin_test.wasm
--r--r--r-- 3 root root 205035 Jan  1  1970 nix_wasm_plugin_yaml.wasm
+.r--r--r--@  20k root 31 Dec  1969 nix_wasm_plugin_fib.wasm
+.r--r--r--@  71k root 31 Dec  1969 nix_wasm_plugin_fib_wasi.wasm
+.r--r--r--@  33k root 31 Dec  1969 nix_wasm_plugin_grep.wasm
+.r--r--r--@  60k root 31 Dec  1969 nix_wasm_plugin_ini.wasm
+.r--r--r--@  24k root 31 Dec  1969 nix_wasm_plugin_mandelbrot.wasm
+.r--r--r--@ 586k root 31 Dec  1969 nix_wasm_plugin_quickjs.wasm
+.r--r--r--@  20k root 31 Dec  1969 nix_wasm_plugin_test.wasm
+.r--r--r--@ 185k root 31 Dec  1969 nix_wasm_plugin_yaml.wasm
 
-# nix eval --impure --expr 'builtins.wasm ./result/nix_wasm_plugin_fib.wasm "fib" 40'
+# nix eval --impure --expr \
+  'builtins.wasm { path = ./result/nix_wasm_plugin_fib.wasm; function = "fib"; } 40'
 warning: '/nix/store/1c9yg0mv…-nix-wasm-rust-0.1.0/nix_wasm_plugin_fib.wasm' function 'fib': greetings from Wasm!
 165580141
 
-# nix eval --raw --impure --expr 'builtins.wasm ./result/nix_wasm_plugin_mandelbrot.wasm "mandelbrot" { width = 150; }'
+# nix eval --raw --impure --expr \
+  'builtins.wasm { path = ./result/nix_wasm_plugin_mandelbrot.wasm; function = "mandelbrot"; } { width = 150; }'
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -36,20 +36,6 @@
         "url": "https://flakehub.com/f/hercules-ci/flake-parts/0.1"
       }
     },
-    "flake-schemas": {
-      "locked": {
-        "lastModified": 1761577921,
-        "narHash": "sha256-eK3/xbUOrxp9fFlei09XNjqcdiHXxndzrTXp7jFpOk8=",
-        "rev": "47849c7625e223d36766968cc6dc23ba0e135922",
-        "revCount": 107,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.2.0/019a4a84-544d-7c59-b26d-e334e320c932/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%2A.tar.gz"
-      }
-    },
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -83,17 +69,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1772218272,
-        "narHash": "sha256-58OxqvVmSo7y5GuLrt1ogU8tmGvGgtijmaurHPZMSBs=",
-        "owner": "DeterminateSystems",
-        "repo": "nix-src",
-        "rev": "fe3515c2e42b95fb250c22549367285191fb9f5d",
-        "type": "github"
+        "lastModified": 1772664055,
+        "narHash": "sha256-RtKKd4aefzHEzV9sKa8bQdZIY67GJMV0nRS1QZ2E94g=",
+        "rev": "3a96d5668a8df84c2c8d006a04212c17839b977f",
+        "revCount": 24783,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.17.0/019cbb2e-8d12-7212-a98f-73fd1f2342a2/source.tar.gz"
       },
       "original": {
-        "owner": "DeterminateSystems",
-        "repo": "nix-src",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/3"
       }
     },
     "nixpkgs": {
@@ -144,7 +129,6 @@
     },
     "root": {
       "inputs": {
-        "flake-schemas": "flake-schemas",
         "nix": "nix",
         "nixpkgs": [
           "nix",

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,7 @@
 
   inputs = {
     nixpkgs.follows = "nix/nixpkgs";
-    flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*.tar.gz";
-    nix.url = "github:DeterminateSystems/nix-src";
+    nix.url = "https://flakehub.com/f/DeterminateSystems/nix-src/3";
   };
 
   outputs = { self, ... }@inputs:


### PR DESCRIPTION
This PR brings the project README in line with the current interface for Determinate Nix version 3.17.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example commands and code blocks to use structured argument objects and multi-line formatting for clearer output and readability.

* **Chores**
  * Adjusted external source declarations: removed an older input reference and updated another to a revised, pinned source to improve reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->